### PR TITLE
Support for Rails 5 beta >= 4

### DIFF
--- a/app/models/proposal/token.rb
+++ b/app/models/proposal/token.rb
@@ -18,6 +18,7 @@ module Proposal
     }
 
     validates_with ::Proposal::EmailValidator
+    validates_with ::Proposal::ProposableValidator
 
     before_validation on: :create do
       self.token = SecureRandom.base64(15).tr('+/=lIO0', 'pqrsxyz')

--- a/app/models/proposal/token.rb
+++ b/app/models/proposal/token.rb
@@ -10,7 +10,6 @@ module Proposal
 
     validates_presence_of :email,
       :token,
-      :proposable,
       :proposable_type,
       :expires_at
 

--- a/app/models/proposal/token.rb
+++ b/app/models/proposal/token.rb
@@ -1,7 +1,7 @@
 module Proposal
   class Token < ActiveRecord::Base
 
-    belongs_to :resource, polymorphic: true
+    belongs_to :resource, polymorphic: true, optional: true
     belongs_to :proposer, polymorphic: true
 
     serialize :arguments

--- a/app/validators/proposal/proposable_validator.rb
+++ b/app/validators/proposal/proposable_validator.rb
@@ -1,0 +1,11 @@
+module Proposal
+  class ProposableValidator < ActiveModel::Validator
+
+    def validate record
+      unless record.proposable.is_a?(Class)
+        record.errors.add :proposable, "is not a class"
+      end
+    end
+
+  end
+end

--- a/test/proposal_test.rb
+++ b/test/proposal_test.rb
@@ -58,6 +58,7 @@ class ProposalTest < ActiveSupport::TestCase
     proposal = User.propose.to email
     proposal.save
 
+    assert_equal true, proposal.persisted?
     assert_equal proposal.token.class, String
   end
 


### PR DESCRIPTION
UPDATE: there's an important change to ```ActiveRecord::Base``` between 5.0.0.beta3 and beta4, method ```.empty?``` was added and is delegated to ```.all``` - it means that ```.empty?``` now looks if there's any record in the database for particular model.

You use validation of the constantized version of ```proposable_type```, which is a class (returned by the method ```proposable```). Presence' validator calls ```.blank?``` which calls ```.empty?```, and in our case it means calling the method on a class that inherits from AR::Base and testing if there are records in database.

In this PR I propose a change to the way the constantized value is validated. We might even not need that validation since we already validate string 'proposable_type'

@mynameisrufus 