### PR TITLE
Create alias or optional argument for proposals received

### DIFF
--- a/lib/proposal/engine.rb
+++ b/lib/proposal/engine.rb
@@ -39,6 +39,8 @@ module Proposal
     def proposals
       Adapter.where resource_type: self.class.to_s, resource_id: self.id
     end
+
+    alias_method :proposals_received, :proposals
   end
 
   module CanProposeInstanceMethods


### PR DESCRIPTION
We should be able to ask for sent and received proposals if a model can do both (can propose and can have proposals)