### PR TITLE
Differentiate between proposals sent and received

### DIFF
--- a/lib/proposal/engine.rb
+++ b/lib/proposal/engine.rb
@@ -42,8 +42,14 @@ module Proposal
   end
 
   module CanProposeInstanceMethods
+    # Sent
     def proposals
       Adapter.where proposer_type: self.class.to_s, proposer_id: self.id
+    end
+
+    # Received
+    def propositions
+      Adapter.where proposer_type: self.class.to_s, email: self.email
     end
 
     def propose resource = nil

--- a/test/proposal_test.rb
+++ b/test/proposal_test.rb
@@ -5,6 +5,10 @@ class ProposalTest < ActiveSupport::TestCase
     "user@example.com"
   end
 
+  def email2
+    "user2@example.com"
+  end
+
   test "truth" do
     assert_kind_of Module, Proposal
   end
@@ -297,5 +301,14 @@ class ProposalTest < ActiveSupport::TestCase
     proposal.save
 
     assert_equal [proposal], user.proposals
+  end
+
+  test "should return proposals received by proposer instance" do
+    user1 = User.create email: email
+    user2 = User.create email: email2
+    proposal = user1.propose.to email2
+    proposal.save
+
+    assert_equal [proposal], user2.propositions
   end
 end


### PR DESCRIPTION
Feature proposal: ability to ask for sent and received proposals if a model can do both (can propose and can have proposals).

I currently use a workaround in my app

``` ruby
  def invitations_received
    @invitations_received ||= Proposal::Token.preload(:proposer).where(email: self.email)
  end
```
